### PR TITLE
Added workaround for canary to properly work when not deployed on kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ For configuration values related to canary itself, please refer to the [canary s
 | `canary_config_wait`    | ""            | [See canary configuration](https://github.com/grafana/loki/blob/master/docs/operations/loki-canary.md#configuration) |
 | `canary_config_user`    | ""            | [See canary configuration](https://github.com/grafana/loki/blob/master/docs/operations/loki-canary.md#configuration) |
 | `canary_config_pass`    | ""            | [See canary configuration](https://github.com/grafana/loki/blob/master/docs/operations/loki-canary.md#configuration) |
+| `canary_redirect_stdout` | "False"      | Enable workaround to use canary with systemd |
+| `canary_promtail_sd_file`   | "/etc/promtail/file_sd/canary.yml" | File service discovery file to write for promtail to discover |
+| `canary_promtail_file_path` | "/tmp/canary.log" | Logfile to be written by canary and to be parsed by promtail |
+
 
 ## Role Tags
 
@@ -76,6 +80,20 @@ More complex example, that configures [several parameters of loki canary](https:
         canary_config_pass: "test"
         canary_config_labelname: "canary_host"
         canary_config_labelname: {{ ansible_hostname }}
+```
+
+Example to setup canary with systemd to [workaround upstream label issues](https://github.com/grafana/loki/issues/1435)
+
+```yaml
+---
+- hosts: all
+  roles:
+    - role: patrickjahns.loki_canary
+      vars: 
+        canary_config_addr: "http://127.0.0.1:3100"
+        canary_redirect_stdout: True
+        canary_config_labelname: "canary_host"
+        canary_config_labelvalue: "{{ ansible_hostname }}"
 ```
 
 ## Local Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,7 @@ canary_config_pass: ""
 canary_config_tls: False
 canary_config_port: 3500
 canary_config_addr: ""
+
+canary_redirect_stdout: False
+canary_promtail_sd_file: "/etc/promtail/file_sd/canary.yml"
+canary_promtail_file_path: "/tmp/canary.log"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -98,6 +98,20 @@
     - canary
     - canary_install
 
+- name: Create promtail static configuration to discover target
+  template:
+    src: promtail_sd_config.j2
+    dest: "{{ canary_promtail_sd_file }}"
+    mode: 0755
+  when: canary_redirect_stdout|bool
+
+- name: Create logrotate to ensure canary log files does not grow too large
+  template:
+    src: logrotate.j2
+    dest: "/etc/logrotate.d/loki-canary"
+    mode: 0644
+  when: canary_redirect_stdout|bool
+
 - name: Create systemd service unit
   notify:
     - Restart loki-canary

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,0 +1,9 @@
+{{ canary_promtail_file_path }}
+{
+    su {{ canary_system_user }} {{ canary_system_group }}
+    rotate 0
+    daily
+    missingok
+    copytruncate
+    notifempty
+}

--- a/templates/promtail_sd_config.j2
+++ b/templates/promtail_sd_config.j2
@@ -1,0 +1,6 @@
+- targets:
+    - localhost
+  labels:
+    __path__: {{ canary_promtail_file_path }}
+    stream: stdout
+    {{ canary_config_labelname }}: {{ canary_config_labelvalue }}

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -9,39 +9,43 @@ After=network-online.target
 Restart=always
 RestartSec=5
 TimeoutSec=5
+{% if canary_redirect_stdout|bool %}
+StandardOutput=file:{{ canary_promtail_file_path }}
+StandardError=journal
+{% endif %}
 User={{ canary_system_user }}
 Group={{ canary_system_group }}
 ExecStart=/usr/local/bin/loki-canary \
-{% if canary_config_buckets|length -%}
+{% if canary_config_buckets|length %}
     -buckets {{ canary_config_buckets }} \
-{%- endif %}
-{% if canary_conig_interval|length -%}
+{% endif %}
+{% if canary_conig_interval|length %}
     -interval {{ canary_conig_interval }} \
-{%- endif %}
-{% if canary_config_labelname|length -%}
+{% endif %}
+{% if canary_config_labelname|length %}
     -labelname {{ canary_config_labelname }} \
-{%- endif %}
-{% if canary_config_labelvalue|length -%}
+{% endif %}
+{% if canary_config_labelvalue|length %}
     -labelvalue {{ canary_config_labelvalue }} \
-{%- endif %}
-{% if canary_config_pruneinterval|length -%}
+{% endif %}
+{% if canary_config_pruneinterval|length %}
     -pruneinterval {{ canary_config_pruneinterval }} \
-{%- endif %}
-{% if canary_config_size|length -%}
+{% endif %}
+{% if canary_config_size|length %}
     -size {{ canary_config_size }} \
-{%- endif %}
-{% if canary_config_wait|length -%}
+{% endif %}
+{% if canary_config_wait|length %}
     -wait {{ canary_config_wait }} \
-{%- endif %}
-{% if canary_config_user|length -%}
+{% endif %}
+{% if canary_config_user|length %}
     -user {{ canary_config_user }} \
-{%- endif %}
-{% if canary_config_pass|length -%}
+{% endif %}
+{% if canary_config_pass|length %}
     -user {{ canary_config_pass }} \
-{%- endif %}
-{% if canary_config_tls | bool -%}
+{% endif %}
+{% if canary_config_tls | bool %}
     -tls \
-{%- endif %}
+{% endif %}
     -port {{ canary_config_port }} \
     -addr {{ canary_config_addr }}
 

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -9,13 +9,9 @@ After=network-online.target
 Restart=always
 RestartSec=5
 TimeoutSec=5
-{% if canary_redirect_stdout|bool %}
-StandardOutput=file:{{ canary_promtail_file_path }}
-StandardError=journal
-{% endif %}
 User={{ canary_system_user }}
 Group={{ canary_system_group }}
-ExecStart=/usr/local/bin/loki-canary \
+ExecStart=/bin/sh -c "exec /usr/local/bin/loki-canary \
 {% if canary_config_buckets|length %}
     -buckets {{ canary_config_buckets }} \
 {% endif %}
@@ -47,7 +43,11 @@ ExecStart=/usr/local/bin/loki-canary \
     -tls \
 {% endif %}
     -port {{ canary_config_port }} \
-    -addr {{ canary_config_addr }}
+{% if canary_redirect_stdout|bool %}
+    -addr {{ canary_config_addr }} >> {{ canary_promtail_file_path }}"
+{% else %}
+    -addr {{ canary_config_addr }}"
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Motivation

Currently canary is hardcoded with the labels `stdout` - see: https://github.com/grafana/loki/issues/1435
When just relying on systemd/journal for publishing the messages from canary+promtail to loki, the field would not be correctly set, or unexpected entries would appear in the log file

# Description

- the systemd unit was configured to redirect canary stdout to a log file to be parsed by promtail
- a service discovery file will be written to promtails `file_sd` directory so promtail discovers the canary log file
- logrotate was added to prevent the size of the canary log growing out of hand