### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: |
           VERSION=$(echo "${COMMIT_MSG}" | grep -Po '\d.\d.\d')
-          CHANGELOG=$(cat CHANGELOG.md | grep -Pzo '(?s)##.*?##')
+          CHANGELOG=$(cat CHANGELOG.md | sed -n '/^## \[/{p; :loop n; /^## \[/q; p; b loop}')
           CHANGELOG="${CHANGELOG%??}"
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For configuration values related to canary itself, please refer to the [canary s
 
 | Name                    | Default Value | Description                        |
 | ----------------------- | ------------- | -----------------------------------|
-| `canary_version`        | "1.4.1        | canary package version. Also accepts *latest* as parameter. |
+| `canary_version`        | "1.5.0"       | canary package version. Also accepts *latest* as parameter. |
 | `canary_system_user`    | loki-canary   | User the canary process will run at |
 | `canary_system_group`   | "{{ canary_system_user }}" | Group of the *canary* user |
 | `canary_install_dir`    | "/opt/loki-canary" | Directory where canary binaries will be installed |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-canary_version: "1.4.1"
+canary_version: "1.5.0"
 canary_dist_url: "https://github.com/grafana/loki/releases/download/v{{ canary_version }}/loki-canary-{{ go_system }}-{{ go_arch }}.zip"
 canary_system_user: loki-canary
 canary_system_group: "{{ canary_system_user }}"


### PR DESCRIPTION
# Motivation

Have a properly automated release workflow

# Description

Using grep in pcre mode was a quick and dirty solution, however needing to deal with multiple matches it became apparent that its easier to use a simple sed stream to select the first match and then exit