### PR TITLE
chore(binary): bump canary version to 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For configuration values related to canary itself, please refer to the [canary s
 
 | Name                    | Default Value | Description                        |
 | ----------------------- | ------------- | -----------------------------------|
-| `canary_version`        | "1.5.0"       | canary package version. Also accepts *latest* as parameter. |
+| `canary_version`        | "1.6.1"       | canary package version. Also accepts *latest* as parameter. |
 | `canary_system_user`    | loki-canary   | User the canary process will run at |
 | `canary_system_group`   | "{{ canary_system_user }}" | Group of the *canary* user |
 | `canary_install_dir`    | "/opt/loki-canary" | Directory where canary binaries will be installed |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-canary_version: "1.5.0"
+canary_version: "1.6.1"
 canary_dist_url: "https://github.com/grafana/loki/releases/download/v{{ canary_version }}/loki-canary-{{ go_system }}-{{ go_arch }}.zip"
 canary_system_user: loki-canary
 canary_system_group: "{{ canary_system_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -69,6 +69,7 @@
     dest: "{{ canary_tmp_dir }}/{{ canary_version }}_canary-{{ go_system }}-{{ go_arch }}.zip"
     force: True
     checksum: "sha256:{{ __canary_checksum }}"
+    mode: 0755
   tags:
     - canary
     - canary_install
@@ -81,6 +82,7 @@
     dest: "{{ canary_install_dir }}/{{ canary_version }}"
     creates: "{{ canary_install_dir }}/{{ canary_version }}/loki-canary-{{ go_system }}-{{ go_arch }}"
     remote_src: True
+    mode: 0755
   tags:
     - canary
     - canary_install
@@ -118,6 +120,7 @@
   template:
     src: service.j2
     dest: /etc/systemd/system/loki-canary.service
+    mode: 0644
   tags:
     - canary
     - canary_install


### PR DESCRIPTION
# Motivation

Deploy up-to-date canary versions