### PR TITLE
chore: bump canary to version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For configuration values related to canary itself, please refer to the [canary s
 
 | Name                    | Default Value | Description                        |
 | ----------------------- | ------------- | -----------------------------------|
-| `canary_version`        | "1.6.1"       | canary package version. Also accepts *latest* as parameter. |
+| `canary_version`        | "2.0.0"       | canary package version. Also accepts *latest* as parameter. |
 | `canary_system_user`    | loki-canary   | User the canary process will run at |
 | `canary_system_group`   | "{{ canary_system_user }}" | Group of the *canary* user |
 | `canary_install_dir`    | "/opt/loki-canary" | Directory where canary binaries will be installed |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-canary_version: "1.6.1"
+canary_version: "2.0.0"
 canary_dist_url: "https://github.com/grafana/loki/releases/download/v{{ canary_version }}/loki-canary-{{ go_system }}-{{ go_arch }}.zip"
 canary_system_user: loki-canary
 canary_system_group: "{{ canary_system_user }}"


### PR DESCRIPTION
# Motivation

Use latest canary version